### PR TITLE
ADD ability to set custom PHP binary path for scheduler_cron.sh

### DIFF
--- a/scheduler_cron.sh
+++ b/scheduler_cron.sh
@@ -74,13 +74,8 @@ acquire_lock () {
     fi
 }
 
-
-# Location of the php binary
+# Default Location of the php binary (if --php /path/to/custom/php/bin is not set)
 PHP_BIN=$(which php || true)
-if [ -z "${PHP_BIN}" ]; then
-    echo "Could not find a binary for php" 1>&2
-    exit 1
-fi
 
 # Location of the md5sum binary
 MD5SUM_BIN=$(which md5sum || true)
@@ -133,6 +128,10 @@ while [ $# -gt 0 ]; do
             EXCLUDE_JOBS=$2
             shift 2
         ;;
+        --php)
+            PHP_BIN=$2
+            shift 2
+        ;;
         --)
             shift
             break
@@ -143,6 +142,12 @@ while [ $# -gt 0 ]; do
         ;;
     esac
 done
+
+# Verify PHP binary:
+if [ -z "${PHP_BIN}" ]; then
+    echo "Could not find a binary for php" 1>&2
+    exit 1
+fi
 
 # Verify we have a MODE parameter
 if [ -z "${MODE}" ]; then


### PR DESCRIPTION
usage:
add this to the command you are executing for running scheduler_cron.sh:
scheduler_cron.sh --php /path/to/custom/php/bin --mode always

useful when you don't want to run cron with the systems default PHP binary

Fixes #251
More elegant solution for #193
Might Fix #125